### PR TITLE
fix(server): server wait group

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/tls"
+	"sync"
 )
 
 type Option func(o *Options)
@@ -11,6 +12,7 @@ type Options struct {
 	EnableTLS  bool
 	ACMEHosts  []string
 	TLSConfig  *tls.Config
+	Wait *sync.WaitGroup
 }
 
 func ACMEHosts(hosts ...string) Option {
@@ -34,5 +36,14 @@ func EnableTLS(b bool) Option {
 func TLSConfig(t *tls.Config) Option {
 	return func(o *Options) {
 		o.TLSConfig = t
+	}
+}
+
+func Wait(wg *sync.WaitGroup) Option {
+	return func(o *Options) {
+		if wg == nil {
+			wg = new(sync.WaitGroup)
+		}
+		o.Wait = wg
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -98,5 +98,10 @@ func (s *server) Start() error {
 func (s *server) Stop() error {
 	ch := make(chan error)
 	s.exit <- ch
+
+	if s.opts.Wait != nil {
+		s.opts.Wait.Wait()
+	}
+
 	return <-ch
 }


### PR DESCRIPTION
### Description

Introduces the ability to set a wait-group to the `go-api/server` to ensure in-flight requests are gracefully handled upon shutdown.

Upon `Stop()`, `Wait()`ing **after** the exit channel has been pushed onto, ensures the listener stops accepting any new requests while it awaits in-flight requests to complete.
