### PR TITLE
feat(shutdown): ensure go-api server gracefully shuts down

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -79,9 +79,9 @@ func (s *server) Start() error {
 
 	s.mtx.Lock()
 	s.address = l.Addr().String()
-	srv := &http.Server{Handler: s.mux}
 	s.mtx.Unlock()
 
+	srv := &http.Server{Handler: s.mux}
 	go func() {
 		if err = srv.Serve(l); err != nil {
 			// Ignore err as per original micro implementation.

--- a/server/server.go
+++ b/server/server.go
@@ -79,10 +79,7 @@ func (s *server) Start() error {
 
 	s.mtx.Lock()
 	s.address = l.Addr().String()
-	srv := &http.Server{
-		Addr:    s.address,
-		Handler: s.mux,
-	}
+	srv := &http.Server{Handler: s.mux}
 	s.mtx.Unlock()
 
 	go func() {


### PR DESCRIPTION
### Description

Ensures the `go-api` server gracefully shuts down (closes listeners and waits for in-flight requests).